### PR TITLE
Make MarcXMLToJson namespace aware

### DIFF
--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/util/MarcXMLToJson.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/util/MarcXMLToJson.java
@@ -28,6 +28,7 @@ public class MarcXMLToJson {
     JSONObject marcJson = new JSONObject();
     JSONArray fields = new JSONArray();
     DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+    documentBuilderFactory.setNamespaceAware(true);
     DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
     Document document = documentBuilder.parse(new InputSource(new StringReader(marcXML)));
     Element root = document.getDocumentElement();
@@ -45,8 +46,8 @@ public class MarcXMLToJson {
       } else {
         record = root;
       }
-    } else if (root.getTagName().equals("collection")) {
-      NodeList records = root.getElementsByTagName("record");
+    } else if (root.getLocalName().equals("collection")) {
+      NodeList records = root.getElementsByTagNameNS("*", "record");
       if (records != null && records.getLength()==1) {
         record = (Element) records.item(0);
       }
@@ -67,14 +68,14 @@ public class MarcXMLToJson {
       }
       childElement = (Element)childNode;
       String textContent = childElement.getTextContent();
-      if(childElement.getTagName().equals("leader")) {
+      if(childElement.getLocalName().equals("leader")) {
         marcJson.put("leader", textContent);
-      } else if(childElement.getTagName().equals("controlfield")) {
+      } else if(childElement.getLocalName().equals("controlfield")) {
         JSONObject field = new JSONObject();
         String marcTag = childElement.getAttribute("tag");
         field.put(marcTag, textContent);
         fields.add(field);
-      } else if(childElement.getTagName().equals("datafield")) {
+      } else if(childElement.getLocalName().equals("datafield")) {
         JSONObject field = new JSONObject();
         JSONObject fieldContent = new JSONObject();
         String marcTag = childElement.getAttribute("tag");
@@ -86,7 +87,7 @@ public class MarcXMLToJson {
         }
         JSONArray subfields = new JSONArray();
         fieldContent.put("subfields", subfields);
-        NodeList nodeList = childElement.getElementsByTagName("subfield");
+        NodeList nodeList = childElement.getElementsByTagNameNS( "*", "subfield");
         for(int i = 0; i < nodeList.getLength(); i++) {
           Element subField = (Element) nodeList.item(i);
           String code = subField.getAttribute("code");


### PR DESCRIPTION
Kurt, when MARC records come in with the xmlns:marc="http://www.loc.gov/MARC21/slim"  namespace, it seems to throw MarcXMLToJson off. 

I've tried to fix it by making the DOM builder namespace aware and using the wild card namespace (*) and local tag names everywhere. 

Seems to work for the .mrc job we have a problem with - but do you think the changes break something else?