### PR TITLE
Handle (any or no) namespace on the MARC field 'record' (DEVOPS-1198)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## not tagged
 
+ * MARC-to-JSON: Handles (any or no) namespace on the 'record' field (DEVOPS-1198)
  * Bulk XML to Inventory: Add option to filter XML bulk records by date (MKH-537)
  * Inventory match key processing: pass on localIdentifier, identifierTypeId (MKH-536)
  * Use `lastHarvestStarted` for `fromDate` (MKH-534)

--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/util/MarcXMLToJson.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/util/MarcXMLToJson.java
@@ -5,9 +5,12 @@
  */
 package com.indexdata.masterkey.localindices.util;
 
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.StringReader;
 
+import java.util.Scanner;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -39,9 +42,9 @@ public class MarcXMLToJson {
       Element metadata = (Element)topRecord.getElementsByTagName("metadata").item(0);
       record = (Element) metadata.getElementsByTagName("record").item(0);
     } else if (root.getTagName().equals("record")) {
-      NodeList recordsEmbeddedInRecord = root.getElementsByTagName("record");
+      NodeList recordsEmbeddedInRecord = root.getElementsByTagNameNS("*","record");
       if (recordsEmbeddedInRecord != null && recordsEmbeddedInRecord.getLength()==1) {
-        // e.g. a MARC record embeddded in OAI-PMH record
+        // e.g. a MARC record embedded in OAI-PMH record
         record = (Element) recordsEmbeddedInRecord.item(0);
       } else {
         record = root;
@@ -106,6 +109,26 @@ public class MarcXMLToJson {
     }
 
     return marcJson;
+  }
+
+  /**
+   * Test method, pass full path to the MARC XML file to parse as the argument to main.
+   */
+  public static void main (String[] args) {
+    File marcRecord = new File(args[0]);
+    try {
+      Scanner sc = new Scanner(marcRecord);
+      sc.useDelimiter("\\Z");
+      try {
+        JSONObject parsedMarc = convertMarcXMLToJson(sc.next());
+        System.out.println("Parsed MARC:");
+        System.out.println(parsedMarc.toJSONString());
+      } catch (SAXException | IOException | ParserConfigurationException e) {
+        e.printStackTrace();
+      }
+    } catch (FileNotFoundException fnfe) {
+      fnfe.printStackTrace();
+    }
   }
 
 }


### PR DESCRIPTION
At least one source qualifies the record element with the MARC namespace, as in <marc:record>. 

This change will have the MARC-XML-to-JSON class pick up the record regardless of the namespace label being present.