### PR TITLE
Persisting log history: fix delayed consistency

### DIFF
--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/folio/InventoryRecordUpdater.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/folio/InventoryRecordUpdater.java
@@ -839,8 +839,6 @@ import static com.indexdata.masterkey.localindices.harvest.storage.folio.Transfo
     }
 
     private int getInt(String key) {
-      System.out.println("getInt: " + json.get(key));
-
       return Integer.parseInt(json.get(key).toString());
     }
 


### PR DESCRIPTION
  Harvester doesn't write job status right when a job finishes but rather when the scheduler thread wakes up to check the jobs. Got to send status over to FOLIO when asking FOLIO to pull the job.