### PR TITLE
Persisting log history: fix delayed consistency part 2 (MODHAADM-30)

### DIFF
--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/job/AbstractRecordHarvestJob.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/job/AbstractRecordHarvestJob.java
@@ -198,12 +198,12 @@ public abstract class AbstractRecordHarvestJob implements RecordHarvestJob {
     logger.error(logSubject + ": " + message);
   }
 
-  protected void shutdown() {
+  protected void shutdown(HarvestStatus status) {
     getHarvestable().setDiskRun(false);
     markForUpdate();
     try {
       if (getStorage() != null)
-        getStorage().shutdown();
+        getStorage().shutdown(status);
     } catch (IOException ioe) {
       logger.warn("Storage shutdown exception: " + ioe.getMessage());
     } finally {

--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/job/BulkRecordHarvestJob.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/job/BulkRecordHarvestJob.java
@@ -10,7 +10,6 @@ import java.net.Proxy;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
@@ -29,12 +28,12 @@ import com.indexdata.masterkey.localindices.harvest.storage.StorageException;
 public class BulkRecordHarvestJob extends AbstractRecordHarvestJob {
 
   @SuppressWarnings("unused")
-  private List<URL> urls = new ArrayList<>();
-  private XmlBulkResource resource;
+  private final List<URL> urls = new ArrayList<>();
+  private final XmlBulkResource resource;
   // private RecordStorage transformationStorage;
-  private Proxy proxy;
+  private final Proxy proxy;
   private String errors;
-  private HarvestStatus initialStatus;
+  private final HarvestStatus initialStatus;
 
   private final Date previousHarvestStarted;
 
@@ -151,7 +150,7 @@ public class BulkRecordHarvestJob extends AbstractRecordHarvestJob {
       logError(subject, msg);
     } finally {
       mailMessage(subject, msg);
-      shutdown();
+      shutdown(getStatus());
     }
   }
 

--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/job/ConnectorHarvestJob.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/job/ConnectorHarvestJob.java
@@ -112,7 +112,7 @@ public class ConnectorHarvestJob extends AbstractRecordHarvestJob {
       msg = error + " " + msg;
     } finally {
       mailMessage(subject, msg);
-      shutdown();
+      shutdown(getStatus());
     }
   }
 

--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/job/NoCommitPurgeStorageProxy.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/job/NoCommitPurgeStorageProxy.java
@@ -44,8 +44,8 @@ public class NoCommitPurgeStorageProxy extends RecordStorageProxy {
   }
 
   @Override
-  public void shutdown() throws IOException {
-    getTarget().shutdown();
+  public void shutdown(HarvestStatus status) throws IOException {
+    getTarget().shutdown(status);
   }
 
   @Override

--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/job/OAIRecordHarvestJob.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/job/OAIRecordHarvestJob.java
@@ -281,7 +281,7 @@ public class OAIRecordHarvestJob extends AbstractRecordHarvestJob {
     } finally {
       logger.info("In finally block with subject " + subject + ", message " + msg);
       mailMessage(subject, msg);
-      shutdown();
+      shutdown(getStatus());
     }
   }
 

--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/job/StatusJob.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/job/StatusJob.java
@@ -116,7 +116,7 @@ public class StatusJob extends AbstractRecordHarvestJob {
     finally {
       mailMessage(subject, msg);
       setStatus(HarvestStatus.FINISHED);
-      shutdown();
+      shutdown(getStatus());
     }
   }
 
@@ -307,9 +307,6 @@ public class StatusJob extends AbstractRecordHarvestJob {
   /**
    * Gets all harvestables (after overall filtering) that are tagged by 'usedBy'
    *  
-   * @param harvestables
-   * @param usedBy
-   * @return
    */
   private List<Harvestable> getHarvestablesByUsedByTag (List<Harvestable> harvestables, String usageTag) {
     List<Harvestable> harvestablesFiltered = new ArrayList<Harvestable>();

--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/ConsoleRecordStorage.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/ConsoleRecordStorage.java
@@ -1,5 +1,6 @@
 package com.indexdata.masterkey.localindices.harvest.storage;
 
+import com.indexdata.masterkey.localindices.harvest.job.HarvestStatus;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collection;
@@ -127,7 +128,7 @@ public class ConsoleRecordStorage implements RecordStorage {
   }
 
   @Override
-  public void shutdown() throws IOException{
+  public void shutdown(HarvestStatus status) throws IOException{
     message("Closing/shutdown ConsoleStorage");
   }
 

--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/DuplicateKeyCheckerRecordStorage.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/DuplicateKeyCheckerRecordStorage.java
@@ -1,5 +1,6 @@
 package com.indexdata.masterkey.localindices.harvest.storage;
 
+import com.indexdata.masterkey.localindices.harvest.job.HarvestStatus;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collection;
@@ -132,7 +133,7 @@ public class DuplicateKeyCheckerRecordStorage implements RecordStorage {
   }
 
   @Override
-  public void shutdown() {
+  public void shutdown(HarvestStatus status) {
     // TODO Auto-generated method stub
   }
 

--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/FileStorage.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/FileStorage.java
@@ -6,6 +6,7 @@
 
 package com.indexdata.masterkey.localindices.harvest.storage;
 
+import com.indexdata.masterkey.localindices.harvest.job.HarvestStatus;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -154,7 +155,7 @@ public class FileStorage implements RecordStorage {
   }
 
   @Override
-  public void shutdown() {
+  public void shutdown(HarvestStatus status) {
     logger.debug("Closing Storage");
     try {
       out.close();

--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/MultiFileStorage.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/MultiFileStorage.java
@@ -6,6 +6,7 @@
 
 package com.indexdata.masterkey.localindices.harvest.storage;
 
+import com.indexdata.masterkey.localindices.harvest.job.HarvestStatus;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -279,7 +280,7 @@ public class MultiFileStorage implements RecordStorage {
   }
 
   @Override
-  public void shutdown() throws IOException {
+  public void shutdown(HarvestStatus status) throws IOException {
     // TODO Auto-generated method stub
   }
 

--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/RecordStorage.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/RecordStorage.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import com.indexdata.masterkey.localindices.entity.Harvestable;
 import com.indexdata.masterkey.localindices.harvest.job.StorageJobLogger;
+import com.indexdata.masterkey.localindices.harvest.job.HarvestStatus;
 
 public interface RecordStorage  {
 
@@ -81,7 +82,7 @@ public interface RecordStorage  {
   DatabaseContenthandler getContentHandler();
 
   // Some storages needs to close resources/shutdown connections.
-  void shutdown() throws IOException;
+  void shutdown(HarvestStatus status) throws IOException;
 
   /**
    * Sets number of record stored within a single batch.

--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/RecordStorageProxy.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/RecordStorageProxy.java
@@ -1,5 +1,6 @@
 package com.indexdata.masterkey.localindices.harvest.storage;
 
+import com.indexdata.masterkey.localindices.harvest.job.HarvestStatus;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collection;
@@ -104,7 +105,7 @@ public abstract class RecordStorageProxy implements RecordStorage {
   };
 
   @Override
-  public void shutdown() throws IOException {
-    storage.shutdown();
+  public void shutdown(HarvestStatus status) throws IOException {
+    storage.shutdown(status);
   }
 }

--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/SingleFileStorage.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/SingleFileStorage.java
@@ -6,6 +6,7 @@
 
 package com.indexdata.masterkey.localindices.harvest.storage;
 
+import com.indexdata.masterkey.localindices.harvest.job.HarvestStatus;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -138,7 +139,7 @@ public class SingleFileStorage implements RecordStorage {
   }
 
   @Override
-  public void shutdown() {
+  public void shutdown(HarvestStatus status) {
     try {
       fos.close();
     } catch (IOException e) {

--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/SolrRecordStorage.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/SolrRecordStorage.java
@@ -1,5 +1,6 @@
 package com.indexdata.masterkey.localindices.harvest.storage;
 
+import com.indexdata.masterkey.localindices.harvest.job.HarvestStatus;
 import java.io.IOException;
 import java.io.Serializable;
 import java.text.SimpleDateFormat;
@@ -412,7 +413,7 @@ public class SolrRecordStorage implements RecordStorage {
   }
 
   @Override
-  public void shutdown() {
+  public void shutdown(HarvestStatus status) {
     storageStatus =  new SimpleStorageStatus(storageStatus);
     logger.info("SolrRecordStorage shutdown");
     server.shutdown();

--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/SplitTransformationChainRecordStorageProxy.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/SplitTransformationChainRecordStorageProxy.java
@@ -1,5 +1,6 @@
 package com.indexdata.masterkey.localindices.harvest.storage;
 
+import com.indexdata.masterkey.localindices.harvest.job.HarvestStatus;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
@@ -106,7 +107,7 @@ public class SplitTransformationChainRecordStorageProxy extends RecordStoragePro
   }
 
   @Override
-  public void shutdown() throws IOException {
+  public void shutdown(HarvestStatus status) throws IOException {
       try {
 	if (output != null) {
 	  logger.error("Closing Storage before commit/rollback");
@@ -119,7 +120,7 @@ public class SplitTransformationChainRecordStorageProxy extends RecordStoragePro
 	logger.warn("Exception while closing: " + e.getMessage());
 	e.printStackTrace();
       }
-    super.shutdown();
+    super.shutdown(status);
   }
 
   @Override

--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/StatusNotImplemented.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/StatusNotImplemented.java
@@ -1,6 +1,6 @@
 package com.indexdata.masterkey.localindices.harvest.storage;
 
-public class StatusNotImplemented extends Exception {
+public class StatusNotImplemented extends RuntimeException {
 
   /**
    * 

--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/folio/InventoryRecordUpdater.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/folio/InventoryRecordUpdater.java
@@ -107,7 +107,8 @@ import static com.indexdata.masterkey.localindices.harvest.storage.folio.Transfo
     }
 
     if (response.isError()) {
-      logger.error(response.getErrorReport().getStatusCode() + ": " + response.getErrorReport().getMessage());
+      logger.error("Batch update returned error code "
+          + response.getErrorReport().getStatusCode() + ": " + response.getErrorReport().getMessage());
     } else {
       ctxt.timingsStoringInventoryRecordSet.time(startStorageBatch, batch.size());
       ctxt.storageStatus.incrementAdd(batch.size());
@@ -710,7 +711,7 @@ import static com.indexdata.masterkey.localindices.harvest.storage.folio.Transfo
     request.setHeader("X-Okapi-Tenant", ctxt.folioTenant);
   }
 
-  private class BatchUpsertResponse {
+  private static class BatchUpsertResponse {
     int statusCode;
     public final String ERRORS = "errors";
     public final String METRICS = "metrics";
@@ -839,7 +840,11 @@ import static com.indexdata.masterkey.localindices.harvest.storage.folio.Transfo
     }
 
     private int getInt(String key) {
-      return Integer.parseInt(json.get(key).toString());
+      if (json.containsKey(key)) {
+        return Integer.parseInt(json.get(key).toString());
+      } else {
+        return -1;
+      }
     }
 
   }


### PR DESCRIPTION
  - forward hand-picked status, lastHarvestStarted, amountHarvested since the properties on the Harvestable cannot be trusted to be up-to-date when mod-harvester-admin fetches them.