### PR TITLE
MODHAADM-36: commons-collections 3.2.2 (CVE-2015-6420, CVE-2015-7501)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- bump the version of the masterkey-common dependency -->
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+      <version>3.2.2</version>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>


### PR DESCRIPTION
Bump commons-collections from 3.2.1 to 3.2.2 fixing arbitrary code execution when deserializing data:

https://nvd.nist.gov/vuln/detail/CVE-2015-7501
https://nvd.nist.gov/vuln/detail/CVE-2015-6420
https://security.snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078
https://security.snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-472711