### PR TITLE
MODHAADM-70: Reduce excessive logging in harvester HttpClientTransport

### DIFF
--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/client/HttpClientTransport.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/client/HttpClientTransport.java
@@ -104,7 +104,7 @@ public class HttpClientTransport implements ClientTransport {
     if (lastFrom != null) {
       try {
         String lastModified = DateUtil.serialize(lastFrom, DateUtil.DateTimeFormat.RFC_GMT);
-        logger.info("Conditional request If-Modified-Since: " + lastModified);
+        logger.debug("Conditional request If-Modified-Since: " + lastModified);
         conn.setRequestProperty("If-Modified-Since", lastModified);
       } catch (ParseException pe) {
         logger.error("Failed to parse last modified date: " + lastFrom);
@@ -140,7 +140,7 @@ public class HttpClientTransport implements ClientTransport {
       }
     } else if (responseCode == 304) {// not-modified
       try {
-        logger.info("Content was not modified since '" + DateUtil.serialize(lastFrom, DateUtil.DateTimeFormat.RFC_GMT) + "', completing.");
+        logger.debug("Content was not modified since '" + DateUtil.serialize(lastFrom, DateUtil.DateTimeFormat.RFC_GMT) + "', completing.");
       } catch (ParseException pe) {
         throw new RuntimeException("Failed to parse Date: " + lastFrom, pe);
       }


### PR DESCRIPTION
https://issues.folio.org/browse/MODHAADM-70

These log lines have a big share of the total log; they are not needed when the module is configured with log level "info". Therefore the code should write them for "debug" only.