### PR TITLE
MODHAADM-78: commons-fileupload 1.5 fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,14 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+      <!-- patch security vulnerabilities:
+           https://security.snyk.io/package/maven/commons-fileupload:commons-fileupload
+      -->
+      <dependency>
+        <groupId>commons-fileupload</groupId>
+        <artifactId>commons-fileupload</artifactId>
+        <version>1.5</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>


### PR DESCRIPTION
localindices uses commons-fileupload 1.2.1:

```
mvn dependency:tree -Dincludes=commons-fileupload:commons-fileupload -Dverbose

[INFO] com.indexdata:harvester:war:2.15.3-SNAPSHOT
[INFO] \- org.apache.solr:solr-core:jar:4.3.1:compile
[INFO]    \- commons-fileupload:commons-fileupload:jar:1.2.1:compile
```

commons-fileupload 1.2.1 has security vulnerabilities including an Arbitrary Code Execution issue: https://security.snyk.io/package/maven/commons-fileupload:commons-fileupload

This fix upgrades it from 1.2.1 to 1.5.