### PR TITLE
MODHAADM-89 Change upsert and delete counters, job status message

### DIFF
--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/folio/InventoryRecordUpdateCounters.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/folio/InventoryRecordUpdateCounters.java
@@ -15,18 +15,20 @@ public class InventoryRecordUpdateCounters {
 
   protected int instancesProcessed = 0;
   protected int instancesLoaded = 0;
-  protected int instanceDeleteSignals = 0;
-  protected int instanceDeletions = 0;
+  protected int instancesDeleted = 0;
+  protected int instanceDeletesSkipped = 0;
   protected int instancesFailed = 0;
 
   protected int holdingsRecordsProcessed = 0;
   protected int holdingsRecordsLoaded = 0;
   protected int holdingsRecordsDeleted = 0;
+  protected int holdingsRecordDeletesSkipped = 0;
   protected int holdingsRecordsFailed = 0;
 
   protected int itemsProcessed = 0;
   protected int itemsLoaded = 0;
   protected int itemsDeleted = 0;
+  protected int itemDeletesSkipped = 0;
   protected int itemsFailed = 0;
 
   protected int sourceRecordsProcessed = 0;

--- a/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/folio/InventoryUpdateContext.java
+++ b/harvester/src/main/java/com/indexdata/masterkey/localindices/harvest/storage/folio/InventoryUpdateContext.java
@@ -81,21 +81,19 @@ public class InventoryUpdateContext extends FolioUpdateContext {
 
         if (!statusWritten) {
             String recordsSkippedMessage = (updateCounters.xmlBulkRecordsSkipped > 0 ? "Records skipped by date filter: " + updateCounters.xmlBulkRecordsSkipped : "");
-            String instancesMessage = "Instances_processed/loaded/deletions(signals)/failed:__" + updateCounters.instancesProcessed + "___" + updateCounters.instancesLoaded + "___" + updateCounters.instanceDeletions + "(" + updateCounters.instanceDeleteSignals + ")___" + updateCounters.instancesFailed + "_";
-            String holdingsRecordsMessage = "Holdings_records_processed/loaded/deleted/failed:__" + updateCounters.holdingsRecordsProcessed + "___" + updateCounters.holdingsRecordsLoaded + "___" + updateCounters.holdingsRecordsDeleted + "___" + updateCounters.holdingsRecordsFailed + "_";
-            String itemsMessage = "Items_processed/loaded/deleted/failed:__" + updateCounters.itemsProcessed + "___" + updateCounters.itemsLoaded + "___" + updateCounters.itemsDeleted + "___" + updateCounters.itemsFailed + "_";
-            String sourceRecordsMessage = "Source_records_processed/loaded/deleted/failed:__" + updateCounters.sourceRecordsProcessed + "___" + updateCounters.sourceRecordsLoaded + "___" + updateCounters.sourceRecordsDeleted + "___" + updateCounters.sourceRecordsFailed + "_";
+            String instancesMessage = "Instances_processed/loaded/deleted(skipped)/failed:__" + updateCounters.instancesProcessed + "___" + updateCounters.instancesLoaded + "___" + updateCounters.instancesDeleted + "(" + updateCounters.instanceDeletesSkipped + ")___" + updateCounters.instancesFailed + "_";
+            String holdingsRecordsMessage = "Holdings_records_processed/loaded/deleted(skipped)/failed:__" + updateCounters.holdingsRecordsProcessed + "___" + updateCounters.holdingsRecordsLoaded + "___" + updateCounters.holdingsRecordsDeleted + "(" + updateCounters.holdingsRecordDeletesSkipped + ")___" + updateCounters.holdingsRecordsFailed + "_";
+            String itemsMessage = "Items_processed/loaded/deleted(skipped)/failed:__" + updateCounters.itemsProcessed + "___" + updateCounters.itemsLoaded + "___" + updateCounters.itemsDeleted + "(" + updateCounters.itemDeletesSkipped + ")___" + updateCounters.itemsFailed + "_";
             if (updateCounters.xmlBulkRecordsSkipped >0) logger.log(Level.INFO, recordsSkippedMessage);
             logger.log((updateCounters.instancesFailed>0 ? Level.WARN : Level.INFO), instancesMessage);
             logger.log((updateCounters.holdingsRecordsFailed>0 ? Level.WARN : Level.INFO), holdingsRecordsMessage);
             logger.log((updateCounters.itemsFailed>0 ? Level.WARN : Level.INFO), itemsMessage);
-            logger.log((updateCounters.sourceRecordsFailed>0 ? Level.WARN : Level.INFO), sourceRecordsMessage);
 
             failedRecordsController.writeLog();
             timingsCreatingRecord.writeLog();
             timingsTransformingRecord.writeLog();
             timingsStoringInventoryRecordSet.writeLog();
-            harvestable.setMessage(recordsSkippedMessage + "  " + instancesMessage + " " + holdingsRecordsMessage + " " + itemsMessage + " " + sourceRecordsMessage);
+            harvestable.setMessage(recordsSkippedMessage + "  " + instancesMessage + " " + holdingsRecordsMessage + " " + itemsMessage );
             statusWritten=true;
         }
     }


### PR DESCRIPTION
  * Add '(skipped)' count for skipped deletes
  * Add delete counts to the 'processed' count (previously only summarized creates and updates)
  * Remove '(signals)' count for instance deletes (only relevant for now defunct shared index)
  * Remove 'source_records' counts (was used for now defunct shared index)