### PR TITLE
MODHAADM-37 exclude commons-beanutils, remove commons-digester

### DIFF
--- a/harvester-admin/pom.xml
+++ b/harvester-admin/pom.xml
@@ -66,11 +66,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>commons-digester</groupId>
-      <artifactId>commons-digester</artifactId>
-      <version>1.5</version>
-    </dependency>
-    <dependency>
       <groupId>javax.el</groupId>
       <artifactId>el-api</artifactId>
       <version>2.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,10 @@
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <!-- bump the version of the masterkey-common dependency -->


### PR DESCRIPTION
  - common-beanutils dependency brought in by masterkey-common and commons-digester, it has arbitrary code execution vulnerability CVE-2014-0114. It appears to be unused.