### PR TITLE
Add new CA cert to Java 8 truststores

### DIFF
--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -36,7 +36,7 @@ jobs:
         run: wget -O /tmp/ca.crt https://download.indexdata.com/pub/id-ssl/ca.crt
 
       - name: Add CA cert to Java 8 TrustStore
-        run: keytool -import -storepass changeit -file /tmp/ca.crt -keystore $JAVA_HOME/jre/lib/security/cacerts
+        run: sudo keytool -import -storepass changeit -file /tmp/ca.crt -keystore $JAVA_HOME/jre/lib/security/cacerts
 
       - name: Create Maven settings
         uses: s4u/maven-settings-action@v4.0.0

--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -36,7 +36,7 @@ jobs:
         run: wget -O /tmp/ca.crt https://download.indexdata.com/pub/id-ssl/ca.crt
 
       - name: Add CA cert to Java 8 TrustStore
-        run: keytool -import -alias myserver -file /tmp/ca.crt -keystore $JAVA_HOME/jre/lib/security/cacerts
+        run: keytool -import -storepass changeit -file /tmp/ca.crt -keystore $JAVA_HOME/jre/lib/security/cacerts
 
       - name: Create Maven settings
         uses: s4u/maven-settings-action@v4.0.0

--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -31,6 +31,13 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
           cache: 'maven'
+
+      - name: Download ID CA cert
+        run: wget -O /tmp/ca.crt https://download.indexdata.com/pub/id-ssl/ca.crt
+
+      - name: Add CA cert to Java 8 TrustStore
+        run: keytool -import -alias myserver -file /tmp/ca.crt -keystore $JAVA_HOME/jre/lib/security/cacerts
+
       - name: Create Maven settings
         uses: s4u/maven-settings-action@v4.0.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ FROM maven:3.6.3-openjdk-8 as builder
 COPY . /usr/src
 
 WORKDIR /usr/src
-RUN mvn clean package
+RUN wget  --no-check-certificate -O /tmp/ca.crt https://download.indexdata.com/pub/id-ssl/ca.crt && \
+    keytool -import -storepass changeit -file /tmp/ca.crt -keystore $JAVA_HOME/jre/lib/security/cacerts -noprompt && \
+    mvn clean package
 
 ### harvester runtime image
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ### Build
-FROM maven:3.6.3-openjdk-8 as builder
+FROM maven:3.6.3-openjdk-8 AS builder
 
 COPY . /usr/src
 
@@ -10,7 +10,7 @@ RUN wget  --no-check-certificate -O /tmp/ca.crt https://download.indexdata.com/p
 
 ### harvester runtime image
 
-FROM jetty:9.4-jre8 as harvester
+FROM jetty:9.4-jre8 AS harvester
 USER root
 RUN mkdir -p /etc/masterkey/harvester && \
     mkdir -p /var/cache/harvester && \
@@ -28,7 +28,7 @@ CMD ["java", "-jar", "/usr/local/jetty/start.jar"]
 
 ### harvester-admin runtime image
 
-FROM jetty:9.4-jre8 as harvester-admin
+FROM jetty:9.4-jre8 AS harvester-admin
 
 USER root
 RUN mkdir -p /etc/masterkey/harvester && \


### PR DESCRIPTION
A newish CA cert for Comodo/Sectigo needs to be added to older Java 8 TrustStores in order for Maven to properly connect to https://maven.indexdata.com.     ID DEVOPS-7567.

